### PR TITLE
remove link-preview-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
     "sharp": "^0.34.2",
     "ws": "^8.18.2"
   },
-  "devDependencies": {
-    "link-preview-js": "^3.1.0"
-  },
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
EN: Removed link-preview-js to improve message sending performance. It was causing delays when sending messages that contain URLs. If required, you can manually install it in your own project

ID: link-preview-js dihapus untuk meningkatkan performa pengiriman pesan. Paket ini menyebabkan delay saat bot mengirim pesan yang mengandung link. Jika dibutuhkan, Anda dapat menginstalnya secara manual di proyek Anda.